### PR TITLE
Don't lose position when changing screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,12 +60,12 @@ dependencies {
     implementation("org.slf4j:slf4j-api:2.1.0-alpha1")
 
     // Java language implementation
-    implementation("androidx.navigation:navigation-fragment:2.9.3")
-    implementation("androidx.navigation:navigation-ui:2.9.3")
+    implementation("androidx.navigation:navigation-fragment:2.9.4")
+    implementation("androidx.navigation:navigation-ui:2.9.4")
 
     // Kotlin
-    implementation("androidx.navigation:navigation-fragment-ktx:2.9.3")
-    implementation("androidx.navigation:navigation-ui-ktx:2.9.3")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.9.4")
+    implementation("androidx.navigation:navigation-ui-ktx:2.9.4")
 
     // Feature module Support
     implementation("com.google.android.play:feature-delivery:2.1.0")
@@ -74,12 +74,12 @@ dependencies {
     implementation("com.google.android.play:app-update:2.1.0")
 
     // Testing Navigation
-    androidTestImplementation("androidx.navigation:navigation-testing:2.9.3")
+    androidTestImplementation("androidx.navigation:navigation-testing:2.9.4")
 
     // Jetpack Compose Integration
-    implementation("androidx.navigation:navigation-compose:2.9.3")
-    implementation("androidx.navigation:navigation-fragment:2.9.3")
-    implementation("androidx.navigation:navigation-ui:2.9.3")
+    implementation("androidx.navigation:navigation-compose:2.9.4")
+    implementation("androidx.navigation:navigation-fragment:2.9.4")
+    implementation("androidx.navigation:navigation-ui:2.9.4")
 
     implementation ("androidx.preference:preference:1.2.1")
     implementation("androidx.fragment:fragment:1.8.9")

--- a/app/src/main/java/com/blackholeofphotography/naturallight/DisplayStatus.java
+++ b/app/src/main/java/com/blackholeofphotography/naturallight/DisplayStatus.java
@@ -179,7 +179,6 @@ public class DisplayStatus
    private static AstroPosition calculateSunPosition (ZonedDateTime when, IGeoPoint where)
    {
       double jd = Julian.JulianFromZonedDateTime (when);
-      //double[] position = Sun.SunTopocentricPosition (jd, where.getLatitude (), where.getLongitude (), 0);
       TopocentricPosition position = Sun.SunTopocentricPosition (jd, where.getLatitude (), where.getLongitude (), 0);
       return new AstroPosition ((float) position.getAzimuth (), (float) position.getElevation ());
    }

--- a/app/src/main/java/com/blackholeofphotography/naturallight/MainActivity.java
+++ b/app/src/main/java/com/blackholeofphotography/naturallight/MainActivity.java
@@ -233,8 +233,6 @@ public class MainActivity extends AppCompatActivity
       DisplayStatus.setZoomLevel (Settings.getZoomLevel ());
       DisplayStatus.setTimeStamp (Settings.getDisplayTime ());
       DisplayStatus.setTimeStamp (Settings.getDisplayTime ());
-
-      //DisplayStatus.forceCalculation ();
    }
 
    public void onPause()

--- a/app/src/main/java/com/blackholeofphotography/naturallight/ui/about/AboutFragment.java
+++ b/app/src/main/java/com/blackholeofphotography/naturallight/ui/about/AboutFragment.java
@@ -47,7 +47,6 @@ public class AboutFragment extends Fragment
          RecyclerView recyclerView = root.findViewById (R.id.librariesList);
 
          adapter = new LibrariesRecyclerAdapter (this.getContext (), getActivity ());
-         recyclerView.setHasFixedSize (true);
          RecyclerView.LayoutManager manager = new LinearLayoutManager (this.getContext ());
          recyclerView.setLayoutManager (manager);
          recyclerView.setAdapter (adapter);


### PR DESCRIPTION
When moving to Detail and  then back to the map screen, it used to lose position and jump to the first saved location.